### PR TITLE
Implement Task 002: inline tool output rendering

### DIFF
--- a/app/frontend/style.css
+++ b/app/frontend/style.css
@@ -91,3 +91,20 @@ h1 {
 #send-button:hover {
     background-color: #0056b3;
 }
+
+.tool-table {
+    border-collapse: collapse;
+    width: 100%;
+    margin-top: 5px;
+}
+
+.tool-table th,
+.tool-table td {
+    border: 1px solid #ccc;
+    padding: 4px 8px;
+    text-align: left;
+}
+
+.tool-table th {
+    background-color: #f0f0f0;
+}

--- a/tests/test_tool_formatters.js
+++ b/tests/test_tool_formatters.js
@@ -1,0 +1,22 @@
+const assert = require('assert');
+const { formatFunctionResponse } = require('../app/frontend/script.js');
+
+const listResp = {
+    name: 'listFiles',
+    response: {
+        items: [
+            { name: 'README.md', type: 'file', path: 'README.md' }
+        ]
+    }
+};
+const html = formatFunctionResponse(listResp);
+assert(html.includes('<table') && html.includes('README.md'));
+console.log('listFiles formatting ok');
+
+const defaultResp = {
+    name: 'fetchFiles',
+    response: { files: { 'a.txt': 'hello' }, status: 'success' }
+};
+const html2 = formatFunctionResponse(defaultResp);
+assert(html2.includes('{\n') || html2.includes('<pre'));
+console.log('default formatting ok');


### PR DESCRIPTION
## Summary
- parse `function_response` entries from model replies
- format `listFiles` and `searchFilesInRepo` results as tables
- render other tool responses as JSON blocks
- style table output
- add a small Node test for `formatFunctionResponse`

## Testing
- `node tests/test_tool_formatters.js`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ae1bd647c83268ce95f446cc295c7